### PR TITLE
Releases can't be fetched anymore

### DIFF
--- a/Classes/Utility/Setup.php
+++ b/Classes/Utility/Setup.php
@@ -135,14 +135,6 @@ class Setup
         $tempPath = MiscUtility::getTemporaryPath();
         $sphinxSourcesPath = static::getSphinxSourcesPath();
 
-        // There is a redirect from the URI in the web interface. E.g.,
-        // https://github.com/sphinx-doc/sphinx/archive/1.3.zip
-        // and the actual download link:
-        // https://codeload.github.com/sphinx-doc/sphinx/zip/1.3
-        if (preg_match('#https://github.com/sphinx-doc/sphinx/archive/([0-9b.]+?)\\.zip#', $url, $matches)) {
-            $url = 'https://codeload.github.com/sphinx-doc/sphinx/zip/' . $matches[1];
-        }
-
         $zipFilename = $tempPath . $version . '.zip';
         static::$log[] = '[INFO] Fetching ' . $url;
         $zipContent = MiscUtility::getUrl($url);

--- a/Classes/Utility/Setup.php
+++ b/Classes/Utility/Setup.php
@@ -152,7 +152,7 @@ class Setup
 
             // Unzip the Sphinx archive
             $out = array();
-            if (static::unarchive($zipFilename, $targetPath, 'sphinx-' . $version)) {
+            if (static::unarchive($zipFilename, $targetPath, 'sphinx-doc-sphinx-')) {
                 $output[] = '[INFO] Sphinx ' . $version . ' has been unpacked.';
 
                 // Patch Sphinx to let us get colored output

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -302,7 +302,7 @@ HTML;
         $success = true;
         $installRst2Pdf = TYPO3_OS !== 'WIN' && $this->configuration['install_rst2pdf'] === '1';
         $version = $data['key'];
-        $url = 'https://github.com' . $data['url'];
+        $url = $data['url'];
 
         if (!Setup::hasSphinxSources($version)) {
             $success &= Setup::downloadSphinxSources($version, $url, $output);


### PR DESCRIPTION
HTML of https://github.com/repos/sphinx-doc/sphinx/releases has been changed meanwhile. Setup::getSphinxAvailableVersions() is not able to fetch available releases anymore.

Patch with refactored use of https://api.github.com/repos/sphinx-doc/sphinx/tags will follow up soon.