### PR TITLE
[TASK] Allow SVG files by default in rsync

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -14,7 +14,7 @@ install_rst2pdf = 0
 plugins =
 
 # cat=advanced//10; type=string; label=LLL:EXT:sphinx/Resources/Private/Language/locallang_db.xlf:settings.build.rsync_files
-rsync_files = rst, txt, yml, gif, jpg, jpeg, png, js, css, sh, cfg
+rsync_files = rst, txt, yml, gif, jpg, jpeg, png, js, css, sh, cfg, svg
 
 # cat=advanced//20; type=int; label=LLL:EXT:sphinx/Resources/Private/Language/locallang_db.xlf:settings.build.processes
 processes = 1


### PR DESCRIPTION
SVG files are often used in TYPO3, for instance for the extensions
icons. On the official documentation renderer, SVG files are
already allowed.